### PR TITLE
Add Python 3 Support

### DIFF
--- a/JSONLibrary/JSONLibraryKeywords.py
+++ b/JSONLibrary/JSONLibraryKeywords.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from robot.api import logger
 from robot.api.deco import keyword
-from version import VERSION
+
+try:
+    from version import VERSION
+except:
+    from JSONLibrary.version import VERSION
+
 import os.path
 import json
 from jsonpath_rw import Index, Fields

--- a/JSONLibrary/__init__.py
+++ b/JSONLibrary/__init__.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
-from JSONLibraryKeywords import JSONLibraryKeywords
-from version import VERSION
+try:
+    from JSONLibraryKeywords import JSONLibraryKeywords
+    from version import VERSION
+except:
+    from JSONLibrary.JSONLibraryKeywords import JSONLibraryKeywords
+    from JSONLibrary.version import VERSION
 
 __author__ = 'Traitanit Huangsri'
 __email__ = 'traitanit.hua@gmail.com'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,13 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup
-from JSONLibrary.version import VERSION
+
+# importing this has the unwanted side-effect of importing
+# other required packages that may not be installed yet
+# resulting in an error
+#from JSONLibrary.version import VERSION
+
+VERSION = '0.2'
 
 requirements = [
     'tox',


### PR DESCRIPTION
This PR adds Python 3 support as requested by issue #11 . Python 2.7 support remains.

Also a change to setup.py allows automatic installation by other packages at the cost of duplicating the VERSION variable. The problem is that setup.py imports JSONLibrary, which executes __init__.py, which imports dependencies that have not been installed yet, causing an error.