### PR TITLE
Remove tox and coverage from library dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ robotframework>=3.0
 jsonpath-rw==1.4.0
 jsonpath-rw-ext>=0.1.9
 coverage==4.2
+tox==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ else:
     VERSION='0.1' #
 
 requirements = [
-    'tox==3.0.0',
-    'coverage',
     'robotframework>=3.0',
     'jsonpath-rw==1.4.0',
     'jsonpath-rw-ext>=0.1.9'


### PR DESCRIPTION
It looks like the library does not use functionality
of tox or coverage packages. Therefore, no need to specify
them in setup.py. However, they are present in requirements.txt,
so this shall be enough.

Fixes #25.