### PR TITLE
issue #9: invalid syntax makes Robot crash

### DIFF
--- a/JSONLibrary/JSONLibraryKeywords.py
+++ b/JSONLibrary/JSONLibraryKeywords.py
@@ -6,12 +6,19 @@ from robot.api import logger
 from robot.api.deco import keyword
 from robot.utils.asserts import assert_true, fail
 from jsonpath_ng import Index, Fields
-from jsonpath_ng.ext import parse
+from jsonpath_ng.ext import parse as parse_ng
 from .version import VERSION
 
 __author__ = 'Traitanit Huangsri'
 __email__ = 'traitanit.hua@gmail.com'
 __version__ = VERSION
+
+def parse(json_path):
+    try:
+        _rv=parse_ng(json_path)
+    except BaseException as e:
+        fail("Parser failed to undestand syntax '{}'. error message: \n{}\n\nYou may raise an issue on https://github.com/h2non/jsonpath-ng".format(json_path,e))
+    return _rv
 
 
 class JSONLibraryKeywords(object):

--- a/JSONLibrary/JSONLibraryKeywords.py
+++ b/JSONLibrary/JSONLibraryKeywords.py
@@ -7,6 +7,7 @@ from robot.api.deco import keyword
 from robot.utils.asserts import assert_true, fail
 from jsonpath_ng import Index, Fields
 from jsonpath_ng.ext import parse as parse_ng
+from jsonpath_ng.exceptions import JsonPathParserError
 from .version import VERSION
 
 __author__ = 'Traitanit Huangsri'
@@ -16,8 +17,9 @@ __version__ = VERSION
 def parse(json_path):
     try:
         _rv=parse_ng(json_path)
-    except BaseException as e:
+    except JsonPathParserError as e:
         fail("Parser failed to undestand syntax '{}'. error message: \n{}\n\nYou may raise an issue on https://github.com/h2non/jsonpath-ng".format(json_path,e))
+    # let other exceptions crash robot
     return _rv
 
 

--- a/acceptance/JSONLibrary.robot
+++ b/acceptance/JSONLibrary.robot
@@ -48,6 +48,14 @@ TestShouldNotHaveValueByJSONPath
 
     Run Keyword And Expect Error  *Match found*  Should Not Have Value In Json    ${json_obj}    $..isMarried
 
+TestInvalidSyntaxByJSONPath
+    [Documentation]  Check that an invalid syntax fail the test and doesn't crash Robot
+    ${value}=    Get Value From Json    ${json_obj}    $.bankAccounts[?(@.amount>=100)].bank
+    Should Be Equal As Strings  "${value}"  "['WesternUnion', 'HSBC']"
+
+    ${res}=  Run Keyword And return status   Get Value From Json    ${json_obj}    $.bankAccounts[?(@.amount=>100)].bank
+    Should Not Be True  ${res} 
+
 TestDeleteObjectByJSONPath
     [Documentation]  Delete object from json object using JSONPath
     ${json_obj}=    Delete Object From Json    ${json_obj}    $..isMarried

--- a/tests/json/example.json
+++ b/tests/json/example.json
@@ -24,6 +24,18 @@
 			"number": "0123-4567-8999"
 		}
 	],
+	"bankAccounts": [
+		{
+			"bank": "WesternUnion",
+			"amount": "503"
+		}, {
+			"bank": "HSBC",
+			"amount": "1320"
+		}, {
+			"bank": "GoldenSack",
+			"amount": "-10"
+		}
+	],
 	"siblings": [],
 	"occupation": null
 }

--- a/tests/test_JSONLibrary.py
+++ b/tests/test_JSONLibrary.py
@@ -99,6 +99,15 @@ class JSONLibraryTest(unittest.TestCase):
         expected_result = []
         self.assertListEqual(expected_result, json_object['phoneNumbers'])
 
+    def test_invalid_syntax_doesnt_crash(self):
+        json_path = '$.bankAccounts[?(@.amount>=100)].bank'
+        values = self.test.get_value_from_json(self.json, json_path)
+        expected_result = ['WesternUnion', 'HSBC']
+        self.assertListEqual(values, expected_result)
+        
+        json_path = "$.bankAccounts[?(@.amount=>100)].bank"
+        self.assertRaises(AssertionError, self.test.get_value_from_json, self.json, json_path)
+
     def test_convert_json_to_string(self):
         json_str = self.test.convert_json_to_string(self.json)
         self.assertTrue(isinstance(json_str, str))


### PR DESCRIPTION
Here's a fix for issue #9. If the jsonpath syntax is incorrect (not understood by the parser), the test will fail instead of throwing an error.