### PR TITLE
Extend convert_json_to_string to forward ensure_ascii to json.dumps

### DIFF
--- a/JSONLibrary/jsonlibrary.py
+++ b/JSONLibrary/jsonlibrary.py
@@ -202,20 +202,22 @@ class JSONLibrary:
         return json_object_cpy
 
     @staticmethod
-    def convert_json_to_string(json_object, indent=None):
+    def convert_json_to_string(json_object, indent=None, ensure_ascii=True):
         """Convert JSON object to string
 
         Arguments:
             - json_object: json as a dictionary object.
             - indent: indent level for pretty-printing, see indent argument of python's [https://docs.python.org/3/library/json.html#json.dump|json.dump()] for details
+            - ensure_ascii: Make sure there is only ascii. Escape all non-ascii characters.
 
         Return new json_string
 
         Examples:
         | ${json_str}=  |  Convert JSON To String | ${json_obj} |
         | ${json_str}=  |  Convert JSON To String | ${json_obj} | indent=${4} |
+        | ${json_str}=  |  Convert JSON To String | ${json_obj} | indent=${4} | ensure_ascii=False |
         """
-        return json.dumps(json_object, indent=indent)
+        return json.dumps(json_object, indent=indent, ensure_ascii=ensure_ascii)
 
     @staticmethod
     def convert_string_to_json(json_string):

--- a/acceptance/JSONLibrary.robot
+++ b/acceptance/JSONLibrary.robot
@@ -82,6 +82,18 @@ TestConvertJSONToString
     ${json_str}=    Convert Json To String    ${json_obj_input}
     Should Be String    ${json_str}
 
+TestEnsureAsciiDefault
+    ${data} =   Set Variable    "{'test':'ueber'}"
+    ${json} =    Convert String To Json    ${data}
+    ${string} =     Convert Json To String    ${json}
+    Should Be Equal    ${string}   ${data}
+
+TestEnsureAsciiFalse
+    ${data} =   Set Variable    "{'test':'über'}"
+    ${json} =    Convert String To Json    ${data}
+    ${string} =     Convert Json To String    ${json}   ensure_ascii=False
+    Should Be Equal    ${string}   ${data}
+
 TestDumpJSONToFile
     [Documentation]    Dumps Json to file
     Dump Json to file    ${TEMPDIR}/sample_dump.json    ${json_obj_input}


### PR DESCRIPTION
Forward ensure_ascii to json.dumps and add parameter ensure_ascii to the arguments of "Convert Json To String".

Possible workaround for: https://github.com/robotframework-thailand/robotframework-jsonlibrary/issues/59